### PR TITLE
Add status to CSV output; to prevent using retired addresses.

### DIFF
--- a/converter/constants.py
+++ b/converter/constants.py
@@ -55,7 +55,8 @@ CSV_HEADER = [
     'streetname_de',
     'streetname_fr',
     'streetname_nl',
-    'region_code'
+    'region_code',
+    'status'
 ]
 
 # Transformer for the Lambert 72 coordinates to WGS 84

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -190,6 +190,9 @@ def read_address(element):
             address['house_number'] = child.text
         elif 'boxNumber' == tag:
             address['box_number'] = child.text
+        elif 'addressStatus' == tag:
+            address['status'] = child.findtext(
+                'com:status', namespaces=NS)
         elif 'hasStreetname' == tag:
             address['street_id'] = child.findtext(
                 'com:Streetname/com:objectIdentifier', namespaces=NS)


### PR DESCRIPTION
Current CSV output has duplicate addresses. Now the CSV can be filtered to get current addresses only.